### PR TITLE
Use basespace CLI in download app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## MIPTools (development version)
 
+### New Features
+
+- New `download` app supersedes the previous `download` app, which has been
+  renamed to `download_superseded`. The new app improves the method for
+  downloading data from the Illumina BaseSpace Sequence Hub by using the
+  official command line tool (@arisp99, #25, #13).
+
 ### Bug Fixes
 
 - Fix missing file error when MIP arms file is created from the MIP info

--- a/MIPTools.def
+++ b/MIPTools.def
@@ -464,7 +464,7 @@ From: amd64/ubuntu:20.04
     export BASESPACE_ACCESS_TOKEN=$(sed "2q;d" ${config_path} | sed "s/.*=.//g")
 
     # Download data
-    bs download run -i ${run_id} -o ${output_path}/${run_id}
+    bs download run --summary -i ${run_id} -o ${output_path}/${run_id}
 
 #################################################################
 ##                   Superseded Download App                   ##

--- a/MIPTools.def
+++ b/MIPTools.def
@@ -400,7 +400,7 @@ From: amd64/ubuntu:20.04
 ##################################################################
 %apprun download
     # Exit if something fails
-    set -e
+    set -eu
 
     # Set default values for paths
     output_path="/opt/analysis"
@@ -410,7 +410,7 @@ From: amd64/ubuntu:20.04
         echo "Download data from the Illumina BaseSpace Sequence Hub."
         echo ""
         echo "Usage:"
-        echo "  singularity run [options] --app bs_download <container>"\
+        echo "  singularity run [options] --app download <container>"\
         "[app_options]"
         echo ""
         echo "Options:"
@@ -435,7 +435,7 @@ From: amd64/ubuntu:20.04
         echo "  $ singularity run \\"
         echo "    -B \$resource_dir:/opt/resources \\"
         echo "    -B \$run_dir:/opt/analysis \\"
-        echo "    --app bs_download <container> -i <run_id>"
+        echo "    --app download <container> -i <run_id>"
     }
     
     # Parse options
@@ -482,8 +482,8 @@ From: amd64/ubuntu:20.04
         echo "  downloading data."
         echo ""
         echo "Usage:"
-        echo "  singularity run [options] --app download <container>"\
-        "[app_options]"
+        echo "  singularity run [options] --app download_superseded \\"
+        echo "  <container> [app_options]"
         echo ""
         echo "Options:"
         echo "  See 'singularity run'."
@@ -507,7 +507,7 @@ From: amd64/ubuntu:20.04
         echo "  $ singularity run \\"
         echo "    -B \${resource_dir}:/opt/resources"\
         "-B \${output_dir}:/opt/analysis \\"
-        echo "    --app download <container> -r <run_id>"
+        echo "    --app download_superseded <container> -r <run_id>"
     }
 
     while getopts "hr:" opt; do

--- a/MIPTools.def
+++ b/MIPTools.def
@@ -189,6 +189,10 @@ From: amd64/ubuntu:20.04
     # install parasight
     scp /opt/programs/parasight_v7.6/parasight.pl /opt/bin/parasight76.pl
 
+    # install basespace cli
+    BS_PATH="https://launch.basespace.illumina.com/CLI/latest/amd64-linux/bs"
+    wget $BS_PATH -O /opt/bin/bs
+
     # add executable flag to executables
     chmod -R +xr /usr/bin
     chmod -R +xr /opt/bin

--- a/MIPTools.def
+++ b/MIPTools.def
@@ -396,9 +396,76 @@ From: amd64/ubuntu:20.04
     . /opt/analysis/wrangle.sh
 
 ##################################################################
-##                         Download App                         ##
+##                    Basespace Download App                    ##
 ##################################################################
 %apprun download
+    # Exit if something fails
+    set -e
+
+    # Set default values for paths
+    output_path="/opt/analysis"
+    config_path="/opt/resources/basespace.cfg"
+
+    help() {
+        echo "Download data from the Illumina BaseSpace Sequence Hub."
+        echo ""
+        echo "Usage:"
+        echo "  singularity run [options] --app bs_download <container>"\
+        "[app_options]"
+        echo ""
+        echo "Options:"
+        echo "  See 'singularity run'."
+        echo ""
+        echo "App Options:"
+        echo "  -i    Required. The run ID of the data to download."
+        echo "  -o    The path to the output directory."
+        echo "        Default: '/opt/analysis'."
+        echo "  -c    The path to the authentication credentials file."
+        echo "        This file is created by 'bs auth'. For additional"
+        echo "        information see the help page for that command."
+        echo "        Default: '/opt/resources/basespace.cfg'."
+        echo "  -h    Print the help page."
+        echo ""
+        echo "Examples:"
+        echo "  # Set paths"
+        echo "  $ resource_dir=/bin/MIPTools/base_resources"
+        echo "  $ run_dir=/work/usr/example"
+        echo ""
+        echo "  # Run app"
+        echo "  $ singularity run \\"
+        echo "    -B \$resource_dir:/opt/resources \\"
+        echo "    -B \$run_dir:/opt/analysis \\"
+        echo "    --app bs_download <container> -i <run_id>"
+    }
+    
+    # Parse options
+    while getopts "i:o:c:h" opt; do
+      case "${opt}" in
+        c) config_path=${OPTARG} ;;
+        h) help
+           exit 1 ;;
+        i) run_id=${OPTARG} ;;
+        o) ouput_path=${OPTARG} ;;
+        *) help
+           exit 1 ;;
+      esac
+    done
+    
+    # Ensure run_id is specified
+    if [ ! $run_id ]; then
+      echo "Argument -i must be provided"
+      echo "$usage" >&2
+      exit 1
+    fi
+
+    # Read data from config file
+    # Remove whitespace from each line and export each line as a variable
+    export BASESPACE_API_SERVER=$(sed "1q;d" ${config_path} | sed "s/.*=.//g")
+    export BASESPACE_ACCESS_TOKEN=$(sed "2q;d" ${config_path} | sed "s/.*=.//g")
+
+    # Download data
+    bs download run -i ${run_id} -o ${output_path}
+
 #################################################################
 ##                   Superseded Download App                   ##
 #################################################################

--- a/MIPTools.def
+++ b/MIPTools.def
@@ -445,7 +445,7 @@ From: amd64/ubuntu:20.04
         h) help
            exit 1 ;;
         i) run_id=${OPTARG} ;;
-        o) ouput_path=${OPTARG} ;;
+        o) output_path=${OPTARG} ;;
         *) help
            exit 1 ;;
       esac
@@ -464,7 +464,7 @@ From: amd64/ubuntu:20.04
     export BASESPACE_ACCESS_TOKEN=$(sed "2q;d" ${config_path} | sed "s/.*=.//g")
 
     # Download data
-    bs download run -i ${run_id} -o ${output_path}
+    bs download run -i ${run_id} -o ${output_path}/${run_id}
 
 #################################################################
 ##                   Superseded Download App                   ##

--- a/MIPTools.def
+++ b/MIPTools.def
@@ -395,11 +395,20 @@ From: amd64/ubuntu:20.04
 ##                         Download App                         ##
 ##################################################################
 %apprun download
+#################################################################
+##                   Superseded Download App                   ##
+#################################################################
+%apprun download_superseded
     # Exit if something fails or if have unset object
     set -eu
 
     help() {
         echo "Download data from the Illumina BaseSpace Sequence Hub."
+        echo ""
+        echo "Superseded Note:"
+        echo "  Please note that this app has been superseded by the download" 
+        echo "  app, which uses the basespace command line interface for" 
+        echo "  downloading data."
         echo ""
         echo "Usage:"
         echo "  singularity run [options] --app download <container>"\

--- a/MIPTools.def
+++ b/MIPTools.def
@@ -452,9 +452,9 @@ From: amd64/ubuntu:20.04
     done
     
     # Ensure run_id is specified
-    if [ ! $run_id ]; then
+    if [ ! -z ${run_id} ]; then
       echo "Argument -i must be provided"
-      echo "$usage" >&2
+      help >&2
       exit 1
     fi
 

--- a/MIPTools.def
+++ b/MIPTools.def
@@ -496,7 +496,7 @@ From: amd64/ubuntu:20.04
         echo "  An 'access_token.txt' file with a valid access token is"
         echo "  required. It must be present in the 'base_resources' directory."
         echo "  A data directory where the data will be downloaded to must be"
-        echo "  mounted to '/opt/data'."
+        echo "  mounted to '/opt/analysis'."
         echo ""
         echo "Examples:"
         echo "  # Set paths"

--- a/MIPTools.def
+++ b/MIPTools.def
@@ -452,7 +452,7 @@ From: amd64/ubuntu:20.04
     done
     
     # Ensure run_id is specified
-    if [ ! -z ${run_id} ]; then
+    if [ -z ${run_id} ]; then
       echo "Argument -i must be provided"
       help >&2
       exit 1

--- a/base_resources/basespace.cfg
+++ b/base_resources/basespace.cfg
@@ -1,0 +1,2 @@
+apiServer   = https://api.basespace.illumina.com
+accessToken = <access token>


### PR DESCRIPTION
This PR creates a new basespace download app that uses the official basespace CLI. This PR supersedes the work in #13 and introduces one large change. Namely, in order to maintain backward compatibility, we supersede the original download app that uses a python script for downloading data. Users may, therefore, still use the old download app.

Closes #8.