### PR TITLE
Start jupyter no metadata

### DIFF
--- a/MIPTools.def
+++ b/MIPTools.def
@@ -239,7 +239,8 @@ From: amd64/ubuntu:22.04
 
     # Port forwarding setup
     nb_port=$(shuf -i 8000-9999 -n 1)
-    server_ip=$(hostname -i)
+    # server_ip=$(hostname -i)
+    server_ip=$(hostname -I | awk '{print $1}')
     server_user=$(whoami)@$(hostname -f)
     nb_dir=/opt
 

--- a/base_resources/user_scripts_and_config/config.yaml
+++ b/base_resources/user_scripts_and_config/config.yaml
@@ -85,7 +85,8 @@ num_samples_umi: 2
 min_umi: 3
 
 ###### prevalence metadata directory ######
-prevalence_metadata: input_data/metadata_files
+# leave blank if you don't have any metadata files
+prevalence_metadata: 
 
 ####################################################################
 ##                  Advanced Options and Settings                 ##

--- a/base_resources/user_scripts_and_config/start_jupyter.sh
+++ b/base_resources/user_scripts_and_config/start_jupyter.sh
@@ -47,13 +47,22 @@ mkdir -p $(rmwt $variant_calling_folder)
 mkdir -p $(rmwt $wrangler_folder)
 
 # define singularity bindings and snakemake arguments to be used each time snakemake is called
-singularity_bindings="
- -B $(rmwt $project_resources):/opt/project_resources
- -B $(rmwt $species_resources):/opt/species_resources
- -B $(rmwt $wrangler_folder):/opt/user/wrangled_data
- -B $(rmwt $variant_calling_folder):/opt/user/stats_and_variant_calling
- -B $(rmwt $prevalence_metadata):/opt/user/prevalence_metadata
- -B $newhome:/opt/config"
+if [ -z "$prevalence_metadata" ]; then # don't include prevalence data if user has left it blank
+   singularity_bindings="
+    -B $(rmwt $project_resources):/opt/project_resources
+    -B $(rmwt $species_resources):/opt/species_resources
+    -B $(rmwt $wrangler_folder):/opt/user/wrangled_data
+    -B $(rmwt $variant_calling_folder):/opt/user/stats_and_variant_calling
+    -B $newhome:/opt/config"
+else
+   singularity_bindings="
+    -B $(rmwt $project_resources):/opt/project_resources
+    -B $(rmwt $species_resources):/opt/species_resources
+    -B $(rmwt $wrangler_folder):/opt/user/wrangled_data
+    -B $(rmwt $variant_calling_folder):/opt/user/stats_and_variant_calling
+    -B $(rmwt $prevalence_metadata):/opt/user/prevalence_metadata
+    -B $newhome:/opt/config"
+fi
 
 singularity run \
   $singularity_bindings \

--- a/snakemake/wrangler_by_sample_finish.smk
+++ b/snakemake/wrangler_by_sample_finish.smk
@@ -205,7 +205,7 @@ rule concatenate_summary_files:
 		stitch_info_by_target = output_folder + "/stitchInfoByTarget.tsv.gz",
 
 	shell:
-		"""
+		r"""
 		sed -r '1d;s/(\s+)?\S+//2' {output_folder}/analysis/resources/sampleInputFiles.tab.txt |
 			awk '$2=$1' |
 			sed "s/ /\//g;s/$/_mipExtraction\/extractInfoSummary.txt/g;s/^/\/opt\/user\/wrangled_data\/analysis\//g" \

--- a/src/mip_functions.py
+++ b/src/mip_functions.py
@@ -5280,7 +5280,7 @@ def get_haplotype_counts(settings):
     # 3) Estimate the copy number of each "Gene"
     # from the average copy count of uniquely mapping
     # data for all MIPs within the gene.
-    copy_counts.to_csv('copy_counts.csv')
+    # copy_counts.to_csv('copy_counts.csv')
     # cc = copy_counts.groupby(level=["Gene", "Copy"], axis=1).sum()
     cc = copy_counts.T.groupby(level=["Gene", "Copy"]).sum().T
     # gc = copy_counts.groupby(level=["Gene"], axis=1).sum()
@@ -5652,7 +5652,7 @@ def freebayes_call(
         # contigs.fillna({"contains_targets": False}, inplace=True)
         with pd.option_context("future.no_silent_downcasting", True):
             contigs["contains_targets"] = contigs["contains_targets"].fillna(False).infer_objects(copy=False)
-        contigs.to_csv('contigs_new.csv')
+        # contigs.to_csv('contigs_new.csv')
         # create a targets.vcf file for freebayes
         targets_vcf = os.path.join(wdir, "targets.vcf")
         with open(targets_vcf, "w") as outfile:


### PR DESCRIPTION
-  Remove some unnecessary output files that had been used for testing
- Allow user to leave metadata_files variable blank in the config yaml if they don't have any metadata files
- Change method of getting server ip address in the jupyter app in MIPTools.def
- fix "invalid escape sequence" warning message
